### PR TITLE
[BUGFIX] usort should not return bool

### DIFF
--- a/Classes/Controller/PreviewController.php
+++ b/Classes/Controller/PreviewController.php
@@ -94,7 +94,7 @@ class PreviewController
             $sites[] = GeneralUtility::makeInstance(SiteWrapper::class, $site);
         }
         usort($sites, function (SiteWrapper $siteA, SiteWrapper $siteB) {
-            return $siteA->getCountDisabledLanguages() < $siteB->getCountDisabledLanguages();
+            return $siteA->getCountDisabledLanguages() <=> $siteB->getCountDisabledLanguages();
         });
         return $sites;
     }


### PR DESCRIPTION
usort(): Returning bool from comparison function is deprecated, return an integer less than, equal to, or greater than zero

Resolves #12 