### PR TITLE
Add $pageId parameter to getPreviewUrl()

### DIFF
--- a/Classes/Preview/PreviewUriBuilder.php
+++ b/Classes/Preview/PreviewUriBuilder.php
@@ -27,17 +27,25 @@ class PreviewUriBuilder
     {
         $this->sitePreview = $sitePreview;
         $this->hash = md5(uniqid(microtime(), true));
+
+        $this->storeInDatabase();
     }
 
-    public function generatePreviewUrl(?int $pageId = null, ?int $languageId = null): string
+    public function generatePreviewUrl(): string
     {
-        $this->storeInDatabase();
+        return rtrim((string)$this->sitePreview->getLanguage()->getBase(), '/') . '/?' . self::PARAMETER_NAME . '=' . $this->hash;
+    }
 
-        if ($pageId !== null) {
-            return $this->getPreviewUrlForPage($pageId, $languageId);
-        } else {
-            return rtrim((string)$this->sitePreview->getLanguage()->getBase(), '/') . '/?' . self::PARAMETER_NAME . '=' . $this->hash;
-        }
+    public function generatePreviewUrlForPage(int $pageId, ?int $languageId = null): string
+    {
+        $siteRouter = $this->sitePreview->getSite()->getRouter();
+        $languageId = $languageId ?? 0;
+        $queryParameters = [
+            '_language' => $languageId,
+            self::PARAMETER_NAME => $this->hash
+        ];
+
+        return (string)$siteRouter->generateUri($pageId, $queryParameters, '', RouterInterface::ABSOLUTE_URL);
     }
 
     protected function storeInDatabase(): void
@@ -57,17 +65,5 @@ class PreviewUriBuilder
                     ])
                 ]
             );
-    }
-
-    private function getPreviewUrlForPage(int $pageId, ?int $languageId): string
-    {
-        $siteRouter = $this->sitePreview->getSite()->getRouter();
-        $languageId = $languageId ?? 0;
-        $queryParameters = [
-            '_language' => $languageId,
-            self::PARAMETER_NAME => $this->hash
-        ];
-
-        return (string)$siteRouter->generateUri($pageId, $queryParameters, '', RouterInterface::ABSOLUTE_URL);
     }
 }

--- a/Classes/Preview/SitePreview.php
+++ b/Classes/Preview/SitePreview.php
@@ -22,15 +22,13 @@ class SitePreview
 {
     protected bool $valid = false;
     protected ?Site $site = null;
+    protected PreviewUriBuilder $previewUriBuilder;
 
     /** The language ID for the Preview URL */
     protected int $languageId = -1;
 
     /** Time until the preview URl expires */
     protected int $lifeTime = 604800;
-
-    /** The final preview URL */
-    protected string $previewUrl = '';
 
     public function __construct(int $languageId, string $identifier, array $lifetime = [])
     {
@@ -40,7 +38,9 @@ class SitePreview
                 $this->languageId = $languageId;
                 $this->site = $site;
                 $this->calculateLifetime($lifetime);
-                $this->generatePreviewUrl();
+
+                $this->previewUriBuilder = GeneralUtility::makeInstance(PreviewUriBuilder::class, $this);
+
                 $this->valid = true;
             }
         } catch (SiteNotFoundException $e) {
@@ -71,20 +71,19 @@ class SitePreview
         return $this->lifeTime;
     }
 
-    public function getPreviewUrl(?int $pageId = null, ?int $languageId = null): string
+    public function getPreviewUrl(): string
     {
-        $this->generatePreviewUrl($pageId, $languageId);
-        return $this->previewUrl;
+        return $this->previewUriBuilder->generatePreviewUrl();
+    }
+
+    public function getPreviewUrlForPage(int $pageId, ?int $languageId = null): string
+    {
+        return $this->previewUriBuilder->generatePreviewUrlForPage($pageId, $languageId);
     }
 
     public function isValid(): bool
     {
         return $this->valid;
-    }
-
-    protected function generatePreviewUrl(?int $pageId = null, ?int $languageId = null): void
-    {
-        $this->previewUrl = GeneralUtility::makeInstance(PreviewUriBuilder::class, $this)->generatePreviewUrl($pageId, $languageId);
     }
 
     protected function calculateLifetime(array $lifetime): void

--- a/Classes/Preview/SitePreview.php
+++ b/Classes/Preview/SitePreview.php
@@ -71,11 +71,9 @@ class SitePreview
         return $this->lifeTime;
     }
 
-    public function getPreviewUrl(): string
+    public function getPreviewUrl(?int $pageId = null, ?int $languageId = null): string
     {
-        if (empty($this->previewUrl)) {
-            $this->generatePreviewUrl();
-        }
+        $this->generatePreviewUrl($pageId, $languageId);
         return $this->previewUrl;
     }
 
@@ -84,9 +82,9 @@ class SitePreview
         return $this->valid;
     }
 
-    protected function generatePreviewUrl(): void
+    protected function generatePreviewUrl(?int $pageId = null, ?int $languageId = null): void
     {
-        $this->previewUrl = GeneralUtility::makeInstance(PreviewUriBuilder::class, $this)->generatePreviewUrl();
+        $this->previewUrl = GeneralUtility::makeInstance(PreviewUriBuilder::class, $this)->generatePreviewUrl($pageId, $languageId);
     }
 
     protected function calculateLifetime(array $lifetime): void


### PR DESCRIPTION
Instead of always creating a preview URL for the site's language base URL, allow providing a page ID to generate a specific page's URL.