### PR TITLE
[FEATURE] Allow preview URLs for single pages

### DIFF
--- a/Classes/Http/Middleware/PageAccess.php
+++ b/Classes/Http/Middleware/PageAccess.php
@@ -1,0 +1,50 @@
+<?php
+declare(strict_types=1);
+namespace B13\AuthorizedPreview\Http\Middleware;
+
+/*
+ * This file is part of TYPO3 CMS extension authorized_preview by b13.
+ *
+ * It is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU General Public License, either version 2
+ * of the License, or any later version.
+ */
+
+use B13\AuthorizedPreview\Preview\Config;
+use Psr\Http\Message\ResponseInterface;
+use Psr\Http\Message\ServerRequestInterface;
+use Psr\Http\Server\MiddlewareInterface;
+use Psr\Http\Server\RequestHandlerInterface;
+use TYPO3\CMS\Core\Routing\PageArguments;
+use TYPO3\CMS\Core\Utility\GeneralUtility;
+use TYPO3\CMS\Frontend\Controller\ErrorController;
+
+class PageAccess implements MiddlewareInterface
+{
+    public function process(ServerRequestInterface $request, RequestHandlerInterface $handler): ResponseInterface
+    {
+        $config = $request->getAttribute(Preview::REQUEST_ATTRIBUTE);
+        if (!$config instanceof Config || !$config->hasPageRestriction()) {
+            return $handler->handle($request);
+        }
+
+        $pageArguments = $request->getAttribute('routing');
+        if (!$pageArguments instanceof PageArguments) {
+            return GeneralUtility::makeInstance(ErrorController::class)->accessDeniedAction(
+                $request,
+                'Access denied',
+                ['code' => 1667558787]
+            );
+        }
+
+        if ($config->validForPageId($pageArguments->getPageId())) {
+            return $handler->handle($request);
+        }
+
+        return GeneralUtility::makeInstance(ErrorController::class)->accessDeniedAction(
+            $request,
+            'Access denied',
+            ['code' => 1667558788]
+        );
+    }
+}

--- a/Classes/Preview/Config.php
+++ b/Classes/Preview/Config.php
@@ -1,0 +1,50 @@
+<?php
+declare(strict_types=1);
+namespace B13\AuthorizedPreview\Preview;
+
+/*
+ * This file is part of TYPO3 CMS extension authorized_preview by b13.
+ *
+ * It is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU General Public License, either version 2
+ * of the License, or any later version.
+ */
+
+use TYPO3\CMS\Core\Site\Entity\Site;
+use TYPO3\CMS\Core\Site\Entity\SiteLanguage;
+
+class Config
+{
+    public const CONFIG_KEY_SITE = 'siteIdentifier';
+    public const CONFIG_KEY_LANGUAGE = 'languageId';
+    public const CONFIG_KEY_PAGE = 'pageId';
+
+    private string $siteIdentifier = '';
+    private int $languageId = -1;
+    private int $pageId = 0;
+
+    public static function fromJsonString(string $configAsJson): self
+    {
+        $configAsArray = json_decode($configAsJson, true);
+        $config = new self();
+        $config->siteIdentifier = $configAsArray[self::CONFIG_KEY_SITE] ?? '';
+        $config->languageId = $configAsArray[self::CONFIG_KEY_LANGUAGE] ?? -1;
+        $config->pageId = $configAsArray[self::CONFIG_KEY_PAGE] ?? 0;
+        return $config;
+    }
+
+    public function validForSiteAndLanguage(Site $site, SiteLanguage $siteLanguage): bool
+    {
+        return $site->getIdentifier() === $this->siteIdentifier && $siteLanguage->getLanguageId() === $this->languageId;
+    }
+
+    public function hasPageRestriction(): bool
+    {
+        return $this->pageId > 0;
+    }
+
+    public function validForPageId(int $pageId): bool
+    {
+        return $pageId === $this->pageId;
+    }
+}

--- a/Classes/Preview/Exception/SiteMismatchException.php
+++ b/Classes/Preview/Exception/SiteMismatchException.php
@@ -1,0 +1,15 @@
+<?php
+declare(strict_types=1);
+namespace B13\AuthorizedPreview\Preview\Exception;
+
+/*
+ * This file is part of TYPO3 CMS extension authorized_preview by b13.
+ *
+ * It is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU General Public License, either version 2
+ * of the License, or any later version.
+ */
+
+class SiteMismatchException extends \RuntimeException
+{
+}

--- a/Configuration/RequestMiddlewares.php
+++ b/Configuration/RequestMiddlewares.php
@@ -11,6 +11,15 @@ return [
                 'typo3/cms-frontend/static-route-resolver',
                 'typo3/cms-redirects/redirecthandler'
             ]
+        ],
+        'tx_authorized_preview/page-access' => [
+            'target' => B13\AuthorizedPreview\Http\Middleware\PageAccess::class,
+            'before' => [
+                'typo3/cms-frontend/page-argument-validator'
+            ],
+            'after' => [
+                'typo3/cms-frontend/page-resolver',
+            ]
         ]
     ]
 ];

--- a/Resources/Private/Templates/Preview/Index.html
+++ b/Resources/Private/Templates/Preview/Index.html
@@ -8,6 +8,12 @@
 	</f:be.infobox>
 </f:if>
 
+<f:if condition="{error}">
+	<f:be.infobox title="Error while trying to create Preview URL" state="2" iconName="link">
+		<p>Reason: {error}</p>
+	</f:be.infobox>
+</f:if>
+
 <h1>Generate a preview URL to a disabled language</h1>
 
 <div class="panel-group" id="accordion" role="tablist" aria-multiselectable="true">
@@ -48,7 +54,7 @@
 										</div>
 
 										<div class="card-content">
-											<form action="{f:be.uri(route:'site_previews', parameters: {languageId: disabledLanguage.languageId, identifier: site.site.identifier})}"
+											<form action="{f:be.uri(route:'site_previews', parameters: {languageId: disabledLanguage.languageId, identifier: site.site.identifier, pageId:pageId})}"
 												  method="post"
 												  enctype="multipart/form-data"
 												  name="demand"
@@ -70,6 +76,12 @@
 														<option value="day">Day(s)</option>
 													</select>
 												</div>
+												<f:if condition="{pageId}">
+													<br /><br />
+													<div class="form-group">
+														<p><label><input type="checkbox" name="restrictToPage" value="1">&nbsp;Restrict to selected page ({pageId})</label></p>
+													</div>
+												</f:if>
 												<br /><br />
 												<div class="form-group">
 													<button

--- a/ext_localconf.php
+++ b/ext_localconf.php
@@ -1,0 +1,4 @@
+<?php
+defined('TYPO3_MODE') or die('Access denied!');
+
+$GLOBALS['TYPO3_CONF_VARS']['FE']['cacheHash']['excludedParameters'][] = \B13\AuthorizedPreview\Preview\PreviewUriBuilder::PARAMETER_NAME;

--- a/ext_tables.php
+++ b/ext_tables.php
@@ -11,6 +11,7 @@ defined('TYPO3_MODE') or die('Access denied!');
         'access' => 'group,user',
         'name' => 'site_previews',
         'icon' => 'EXT:authorized_preview/Resources/Public/Icons/Extension.svg',
-        'labels' => 'LLL:EXT:authorized_preview/Resources/Private/Language/locallang_module.xlf'
+        'labels' => 'LLL:EXT:authorized_preview/Resources/Private/Language/locallang_module.xlf',
+        'navigationComponentId' => 'TYPO3/CMS/Backend/PageTree/PageTreeElement'
     ]
 );


### PR DESCRIPTION
When creating a preview URL for a single page, access will only be granted for this specific page. To choose a page the backend module makes use of the page tree.

It would be possible to integrate a button in the page module for this as well. This will be implementen in a later patch.