### PR TITLE
[FEATURE] Make it possible to create preview-URLs for enabled languages

### DIFF
--- a/Classes/Preview/Config.php
+++ b/Classes/Preview/Config.php
@@ -47,4 +47,9 @@ class Config
     {
         return $pageId === $this->pageId;
     }
+
+    public function getPageId(): int
+    {
+        return $this->pageId;
+    }
 }

--- a/Classes/SiteWrapper.php
+++ b/Classes/SiteWrapper.php
@@ -10,6 +10,7 @@ namespace B13\AuthorizedPreview;
  * of the License, or any later version.
  */
 
+use TYPO3\CMS\Core\Configuration\ExtensionConfiguration;
 use TYPO3\CMS\Core\Site\Entity\Site;
 use TYPO3\CMS\Core\Site\Entity\SiteLanguage;
 
@@ -27,12 +28,12 @@ class SiteWrapper
      */
     protected array $disabledLanguages = [];
 
-    public function __construct(Site $site)
+    public function __construct(Site $site, ExtensionConfiguration $extensionConfiguration)
     {
         $this->site = $site;
-
+        $showPreviewForEnabledLanguages = (bool)$extensionConfiguration->get('authorized_preview', 'showPreviewForEnabledLanguages');
         foreach ($this->site->getAllLanguages() as $languageId => $language) {
-            if ($language->enabled() === false) {
+            if ($showPreviewForEnabledLanguages && $language->enabled() === false) {
                 $this->disabledLanguages[] = $language;
             }
         }

--- a/ext_conf_template.txt
+++ b/ext_conf_template.txt
@@ -1,0 +1,2 @@
+# cat=basic; type=bool; label=If this is enabled, it is also possible to show preview URLS for enabled languages
+showPreviewForEnabledLanguages = 0


### PR DESCRIPTION
This change makes it possible to provide preview URLs for enabled
site languages as well.

This can be used to provide a preview URL for a hidden page,
for example.

Resolves: #4

-----

Note: this might still need some polishing, I would like to enquire first, if you are interested in merging this. It is currently a proof-of-concept!